### PR TITLE
Update easy-stick-post.php

### DIFF
--- a/easy-stick-post.php
+++ b/easy-stick-post.php
@@ -210,7 +210,7 @@ class WPSE_58818_Stick_Post
      */
     protected static function can_ajax()
     {
-        $post_id = isset($_REQUEST['post_id']) ? $_REQUEST['post_id'] : '';
+        $post_id = isset($_REQUEST['post_id']) ? absint($_REQUEST['post_id']) : '';
 
         if(
             !$post_id ||


### PR DESCRIPTION
It may be overkill but I consider it good practice to immediately clean user data like `$_REQUEST`. If you don’t cast it to an integer your `$post_id` variable still can contain anything.
